### PR TITLE
fix srand on same seed on small image size or fast computer

### DIFF
--- a/x86/linux/src/diffusion_slover.cpp
+++ b/x86/linux/src/diffusion_slover.cpp
@@ -276,7 +276,7 @@ ncnn::Mat DiffusionSlover::sampler(int seed, int step, ncnn::Mat& c, ncnn::Mat& 
 			float sigma_up = min(sigma[i + 1], sqrt(sigma[i + 1] * sigma[i + 1] * (sigma[i] * sigma[i] - sigma[i + 1] * sigma[i + 1]) / (sigma[i] * sigma[i])));
 			float sigma_down = sqrt(sigma[i + 1] * sigma[i + 1] - sigma_up * sigma_up);
 
-			srand(time(NULL));
+			srand(time(NULL) + i);
 			ncnn::Mat randn = randn_4(rand() % 1000);
 			for (int c = 0; c < 4; c++) {
 				float* x_ptr = x_mat.channel(c);

--- a/x86/vs2019_opencv-mobile_ncnn-dll_demo/vs2019_opencv-mobile_ncnn-dll_demo/diffusion_slover.cpp
+++ b/x86/vs2019_opencv-mobile_ncnn-dll_demo/vs2019_opencv-mobile_ncnn-dll_demo/diffusion_slover.cpp
@@ -276,7 +276,7 @@ ncnn::Mat DiffusionSlover::sampler(int seed, int step, ncnn::Mat& c, ncnn::Mat& 
 			float sigma_up = min(sigma[i + 1], sqrt(sigma[i + 1] * sigma[i + 1] * (sigma[i] * sigma[i] - sigma[i + 1] * sigma[i + 1]) / (sigma[i] * sigma[i])));
 			float sigma_down = sqrt(sigma[i + 1] * sigma[i + 1] - sigma_up * sigma_up);
 
-			srand(time(NULL));
+			srand(time(NULL) + i);
 			ncnn::Mat randn = randn_4(rand() % 1000);
 			for (int c = 0; c < 4; c++) {
 				float* x_ptr = x_mat.channel(c);


### PR DESCRIPTION
`time(NULL)` returns second timestamp
Each iteration may cost less than 1 second on small image size (eg 256x256) or fast computer (eg 5950x), thus the same seed causes artifacts

add `i` to resolve the issue